### PR TITLE
Moved code and C++ exception tables to MRAM to fix debugging issues.

### DIFF
--- a/kws/linker/alif-e7-m55-he.ld
+++ b/kws/linker/alif-e7-m55-he.ld
@@ -77,6 +77,16 @@ SECTIONS
     *CMSIS*.obj(.text .rodata*)
 
     *(startup_ro_data)
+
+    *(.text*)
+
+    . = ALIGN(8);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(8);
+    __exidx_start = .;
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    __exidx_end = .;
+
     . = ALIGN(16);
   } > MRAM
 
@@ -106,7 +116,6 @@ SECTIONS
 
   .code.at_itcm : ALIGN(8)
   {
-    *(.text*)
     . = ALIGN(16);
   } > ITCM AT > MRAM
 
@@ -119,12 +128,6 @@ SECTIONS
 
     KEEP(*(.jcr*))
 
-    . = ALIGN(8);
-    *(.ARM.extab* .gnu.linkonce.armextab.*)
-    . = ALIGN(8);
-    __exidx_start = .;
-    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    __exidx_end = .;
     . = ALIGN(16);
   } > DTCM AT > MRAM
 

--- a/object-detection/linker/alif-e7-m55-hp.ld
+++ b/object-detection/linker/alif-e7-m55-hp.ld
@@ -77,6 +77,15 @@ SECTIONS
     *flatbuffer*.obj(.text .rodata*)
     *CMSIS*.obj(.text .rodata*)
     *(startup_ro_data)
+
+    *(.text*)
+
+    . = ALIGN(8);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(8);
+    __exidx_start = .;
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    __exidx_end = .;
   } > MRAM
 
   .copy.table : ALIGN(4)
@@ -105,7 +114,6 @@ SECTIONS
 
   .code.at_itcm : ALIGN(8)
   {
-    *(.text*)
     . = ALIGN(16);
   } > ITCM AT > MRAM
 
@@ -118,12 +126,6 @@ SECTIONS
 
     KEEP(*(.jcr*))
 
-    . = ALIGN(8);
-    *(.ARM.extab* .gnu.linkonce.armextab.*)
-    . = ALIGN(8);
-    __exidx_start = .;
-    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    __exidx_end = .;
     . = ALIGN(16);
   } > DTCM AT > MRAM
 


### PR DESCRIPTION
Debugging was not working as relocations were too far apart. Issue was that breakpoints were not working, did not stop to correct file/place.

This PR moves C++ exception tables to the same memory as C++ libraries which they are linked.

Range on the relocations is +/-1GB so if C++ code is in MRAM (0x80000000) and C++ exception tables were in DTCM (0x20000000) it was too big of a relocation gap.

Tried to move *flatbuffer*.obj(.text .rodata*) to ITCM but not a chance it fits, even if rest of the c code was moved to MRAM.
With next rebase with original code, tensorflow and co are updated and take even more space. Tried also with GCC 13.3.1.

NOTE! This might make running the example a bit slower but as flatbuffers were already on MRAM maybe not so much.
Tested kws and object detection to be working and debuggable.